### PR TITLE
Feature/versioning improvement

### DIFF
--- a/pythosf/client.py
+++ b/pythosf/client.py
@@ -42,9 +42,15 @@ class Session:
             method = method.upper()
         if query_parameters:
             if not query_parameters.get('version', None):
-                query_parameters.update({'version': self.default_version})
+                headers=combine_headers(
+                    headers,
+                    {'Accept-Header': 'application/vnd.api+json;version={}'.format(self.default_version)}
+                )
         else:
-            query_parameters = {'version': self.default_version}
+            headers = combine_headers(
+                headers,
+                {'Accept-Header': 'application/vnd.api+json;version={}'.format(self.default_version)}
+            )
         keep_trying = True
         response = None
 


### PR DESCRIPTION
The bulk of this is to allow depaginating in cases of more than 10 pages by putting version into a header. For _some_ reason, as you got further into the pages, it just kept adding more `&version=2.6`s onto the query params. It's the client's fault, but the easiest way to fix was to move the version into the header. At some point I'll need to add tests.

Also I cleaner up a lot of code to keep the IDE from complaining (mostly whitespace stuff) and I also replaced `print()` with `logging.log()`.