### PR TITLE
add `item_id` to payload instead of `id` builtin

### DIFF
--- a/pythosf/client/session.py
+++ b/pythosf/client/session.py
@@ -30,7 +30,7 @@ class Session:
             if attributes is not None:
                 request_body['attributes'] = attributes
             if item_id is not None:
-                request_body['id'] = id
+                request_body['id'] = item_id
             if item_type is not None:
                 request_body['type'] = item_type
             if request_body is not None:


### PR DESCRIPTION
 * Fixes patch/put requests erroring from trying to serialize built-in function `id`.